### PR TITLE
Handling of ?query=parameters

### DIFF
--- a/lib/Test/HTTP/Server.pm
+++ b/lib/Test/HTTP/Server.pm
@@ -278,7 +278,9 @@ sub out_all
 	);
 	$self->{out_headers} = { %default_headers };
 
-	my $req = $self->{request}->[1];
+	my $raw_uri = $self->{request}->[1];
+	my @req_parts = split m#\?#, $raw_uri;
+	my $req = shift @req_parts;
 	$req =~ s#^/##;
 	my @args = map { uri_unescape $_ } split m#/#, $req;
 	my $func = shift @args;


### PR DESCRIPTION
Right now it just crashs cause there cant be a function that has ? in it :-). It would be nice if the system could ignore this, this allows to make a call to "echo?/some/other/url" to test API proper request execution (you just set $server->uri."echo?" as base URL for the API and check what requests are generated).

Would be very nice if you apply that patch and release soon! :)
